### PR TITLE
avoid needless spam during development by making the test not run during...

### DIFF
--- a/lib/Dist/Zilla/Plugin/ReportVersions/Tiny.pm
+++ b/lib/Dist/Zilla/Plugin/ReportVersions/Tiny.pm
@@ -14,6 +14,13 @@ has include => (is => 'ro', isa => 'ArrayRef', default => sub { [] });
 our $template = q{use strict;
 use warnings;
 use Test::More 0.88;
+
+BEGIN {
+    if ($ENV{AUTHOR_TESTING}) {
+        Test::More::plan(skip_all => 'this test is for users, not authors');
+    }
+}
+
 # This is a relatively nice way to avoid Test::NoWarnings breaking our
 # expectations by adding extra tests, without using no_plan.  It also helps
 # avoid any other test module that feels introducing random tests, or even

--- a/lib/Dist/Zilla/Plugin/ReportVersions/Tiny.pm
+++ b/lib/Dist/Zilla/Plugin/ReportVersions/Tiny.pm
@@ -11,12 +11,15 @@ sub mvp_multivalue_args { qw{exclude include} };
 has exclude => (is => 'ro', isa => 'ArrayRef', default => sub { [] });
 has include => (is => 'ro', isa => 'ArrayRef', default => sub { [] });
 
+has skip_when_author_testing => (is => 'ro', isa => 'Bool', default => 0);
+
 our $template = q{use strict;
 use warnings;
 use Test::More 0.88;
 
 BEGIN {
-    if ($ENV{AUTHOR_TESTING}) {
+    if ($skip_when_author_testing
+        and $ENV{AUTHOR_TESTING}) {
         Test::More::plan(skip_all => 'this test is for users, not authors');
     }
 }
@@ -163,6 +166,7 @@ sub generate_test_from_prereqs {
         module_code => $module_code,
         my_version => __PACKAGE__->VERSION,
         my_package => __PACKAGE__,
+        skip_when_author_testing => $self->skip_when_author_testing || 0,
     });
 
     return $content;
@@ -282,6 +286,17 @@ who suggested adding a list of "interesting modules" to the
 F<Makefile.PL> and checking their version so that the test reports can show
 which version (if any) is in fact installed
 (see the L<CPAN> dist for an example).
+
+=item B<skip_when_author_testing>
+
+  [ReportVersions::Tiny]
+  skip_when_author_testing = 1
+
+defaults to off.
+
+When this option is set, and the AUTHOR_TESTING environment variable is
+enabled, this test is skipped. This helps avoid unwanted spam when you (the
+developer) are testing your own module.
 
 =back
 


### PR DESCRIPTION
... AUTHOR_TESTING

If you like, I can add a flag to enable/disable this behaviour (with whatever default you prefer), but I can't think of any reason why an author would want this test to run during development.

(I also added a few more commits to get this module to build under 5.17.11 with Test::Builder 1.005+.  You may also be interested in Test::DZil, which you can probably use to switch off of Test::MockObject.)
